### PR TITLE
Team Request: Space on readme for creating pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Register as a warden
+# Register as a warden 
 
 Registering as a warden allows you to be listed on our [leaderboard](https://code423n4.com/leaderboard). You'll need to register your handle in order to submit a bug for a contest.
 


### PR DESCRIPTION
As mentioned in https://docs.code4rena.com/roles/wardens#registering-a-team
I added something (1 space after the readme title) to the repo for creating a pull request with the data of the team
 {
  "image": "blob:https://imgur.com/f6389953-32af-4519-89db-f00a10d5ee39",
  "handle": "0x00AlfaHunterZ",
  "members": ["Deivitto", "Bronicle",]
}